### PR TITLE
ElectrOScript 0.1.1

### DIFF
--- a/eoscript-0-1-1.py
+++ b/eoscript-0-1-1.py
@@ -1,0 +1,28 @@
+def ElectrOScript():
+  importCode = "null"
+  x = 1
+  plines = []
+  importCode.split('\n')
+  lines = []
+  while True:
+    line = input()
+    if line != "{end}":
+        lines.append(line)
+    else:
+        break
+  text = '\n'.join(lines)
+  importCode = text.split()
+  if importCode[0] == "{start}":
+  while importCode[x] != "{end}":
+    if "say" in importCode[x]:
+      EScriptLine = list(importCode[x])
+      sayChars = [":)"]
+      if EScriptLine[3] == "(":
+        sayCharCounter = 4
+        output = [""]
+        while EScriptLine[sayCharCounter] != ")":
+          output.append(EScriptLine[sayCharCounter])
+          sayCharCounter += 1
+        print(''.join(output))
+        break
+  x = x + 1


### PR DESCRIPTION
First version of ElectrOS' native programming language. Currently it has only one command, which is say(_string_). Also, you only can enter one command for a script (working to fix it). Script must start with "**{start}**" and end with "**{end}**".